### PR TITLE
Fixes #20, uses getopt instead of php-cli-tools for arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ script:
 - vendor/bin/phpcs
 - "vendor/bin/phpmd ./ text cleancode,codesize,controversial,design,naming,unusedcode --exclude vendor/"
 - "vendor/bin/phpstan analyse src --level 7"
-- "./bin/php-doc-check -d ./ --exclude vendor/"
+- "./bin/php-doc-check --exclude vendor ./"
 - vendor/bin/box compile
-- "php ./bin/php-doc-check.phar -d ./ --exclude vendor/"
+- "php ./bin/php-doc-check.phar --exclude vendor ./"
 before_deploy:
   - echo $DECRYPT_KEY | gpg --passphrase-fd 0 .travis/keys.asc.gpg  
   - gpg --batch --yes --import .travis/keys.asc

--- a/README.md
+++ b/README.md
@@ -25,21 +25,25 @@ For now you have to install the beta version.
 ## Usage
 
 ```
-$vendor/bin/php-doc-check -h
-Flags
-  --help, -h                   Show this help screen
-  --quiet, -q                  Don't show any output
-  --ignore-violations-on-exit  Will exit with a zero code, even if any violations are found
+$vendor/bin/php-doc-check -?
+Usage: vendor/bin/php-doc-check [options] <directory> [<directory>...]
 
-Options
-  --directory, -d                    Directory to scan for files
-  --exclude, -x                      Directories to exclude, comma seperated
-  --format, -f                       Output format: text, json [default: text]
-  --reportfile                       Send report output to a file
-  --complexity-warning-treshold, -w  Cyclomatic complexity score which is the lower bound for a warning [default: 4]
-  --complexity-error-treshold, -e    Cyclomatic complexity score which is the lower bound for an error [default: 6]
-  --file-extensions                  Regex of valid file extensions to scan [default: php|php5|phtml]
+Options:
+  -x, --exclude <arg>                      Directories to exclude, without slash
+  -f, --format <arg>                       Output format: text, json
+  -o, --reportFile <arg>                   Send report output to a file
+  -w, --complexity-warning-treshold <arg>  Cyclomatic complexity score which is
+                                           the lower bound for a warning
+  -e, --complexity-error-treshold <arg>    Cyclomatic complexity score which is
+                                           the lower bound for an error
+  -$, --file-extension <arg>               Valid file extensions to scan
+  -i, --ignore-violations-on-exit          Will exit with a zero code, even if
+                                           any violations are found
+  -?, --help                               Show this help and quit
+  -q, --quiet                              Don't show any output
 ```
+
+Example first use: `vendor/bin/php-doc-check --exclude vendor ./`
 
 ## Examples
 

--- a/bin/php-doc-check
+++ b/bin/php-doc-check
@@ -8,33 +8,8 @@ foreach ([__DIR__ . '/../../../autoload.php', __DIR__ . '/../vendor/autoload.php
     }
 }
 
-$arguments = new \cli\Arguments();
-$arguments->addOption(array('directory', 'd'), array(
-    'default'     => getcwd(),
-    'description' => 'Directory to scan for files'));
-$arguments->addOption(array('exclude', 'x'), array(
-    'default'     => '',
-    'description' => 'Directories to exclude, comma seperated'));
-$arguments->addOption(array('format', 'f'), array(
-    'default'     => 'text',
-    'description' => 'Output format: text, json'));
-$arguments->addOption(array('reportfile'), array(
-    'default'     => '',
-    'description' => 'Send report output to a file'));
-$arguments->addOption(array('complexity-warning-treshold', 'w'), array(
-    'default'     => '4',
-    'description' => 'Cyclomatic complexity score which is the lower bound for a warning'));
-$arguments->addOption(array('complexity-error-treshold', 'e'), array(
-    'default'     => '6',
-    'description' => 'Cyclomatic complexity score which is the lower bound for an error'));
-$arguments->addOption(array('file-extensions'), array(
-    'default'     => 'php|php5|phtml',
-    'description' => 'Regex of valid file extensions to scan'));
-$arguments->addFlag(array('help', 'h'), 'Show this help screen');
-$arguments->addFlag(array('quiet', 'q'), 'Don\'t show any output');
-$arguments->addFlag(array('ignore-violations-on-exit'), 'Will exit with a zero code, even if any violations are found');
-
-$arguments->parse();
+$argumentsProvider = new NdB\PhpDocCheck\ApplicationArgumentsProvider();
+$arguments = $argumentsProvider->getArguments();
 
 $outputChannels = array();
 $cliChannel = new \NdB\PhpDocCheck\Output\Channels\Regular(new \SplFileObject('php://stdout'));
@@ -43,8 +18,8 @@ if($arguments['quiet']){
 }
 $outputChannels[] = $cliChannel;
 
-if (!empty($arguments['reportfile'])) {
-    $outputFile = new SplFileObject(getcwd(). '/' . $arguments['reportfile'], 'w');
+if (!empty($arguments['reportFile'])) {
+    $outputFile = new SplFileObject(getcwd(). '/' . $arguments['reportFile'], 'w');
     $outputChannels[] = new \NdB\PhpDocCheck\Output\Channels\Regular($outputFile);
 }
 
@@ -59,7 +34,7 @@ if (!array_key_exists($arguments['format'], $output_formats)) {
 $outputFormatter = new $output_formats[$arguments['format']]($outputChannels);
 
 if ($arguments['help']) {
-    $outputFormatter->out($arguments->getHelpScreen() . "\n\n");
+    $outputFormatter->out($arguments->getHelpText());
     exit;
 }
 
@@ -78,28 +53,8 @@ $parser = (new \PhpParser\ParserFactory)->create(
 );
 
 $analysisResults = array();
-
-$directory = new RecursiveDirectoryIterator($arguments['directory']);
-$files_to_analyse = new RecursiveIteratorIterator($directory);
-$files_to_analyse = new RegexIterator(
-    $files_to_analyse,
-    '/^.+\.'.$arguments['file-extensions'].'$/i',
-    RecursiveRegexIterator::GET_MATCH
-);
-
-if (!empty($arguments['exclude'])) {
-    foreach (explode(',', $arguments['exclude']) as $excludeDir) {
-        $regex = '/^\.\/(?!'. preg_quote($excludeDir, '/').').+$/';
-        $files_to_analyse = new RegexIterator(
-            $files_to_analyse,
-            $regex,
-            RecursiveRegexIterator::GET_MATCH,
-            RegexIterator::USE_KEY
-        );
-    }
-}
-
-foreach ($files_to_analyse as $name => $object) {
+$fileFinder = new \NdB\PhpDocCheck\FileFinder();
+foreach ($fileFinder->getFiles($arguments) as $name => $object) {
     $file = new \NdB\PhpDocCheck\AnalysableFile(new SplFileInfo($name), $parser, $arguments);
     $result = $file->analyse();
     $outputFormatter->progress($result->getProgressIndicator());

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "minimum-stability": "stable",
     "require": {
         "nikic/php-parser": "^4.2",
-        "wp-cli/php-cli-tools": "^0.11.11"
+        "wp-cli/php-cli-tools": "^0.11.11",
+        "ulrichsg/getopt-php": "^3.2"
     },
     "bin": [
         "bin/php-doc-check"
@@ -23,7 +24,7 @@
             "vendor/bin/phpcs",
             "vendor/bin/phpmd ./ text cleancode,codesize,controversial,design,naming,unusedcode --exclude vendor/",
             "vendor/bin/phpstan analyse src --level 7",
-            "./bin/php-doc-check -d ./ --exclude vendor/"
+            "./bin/php-doc-check --exclude vendor/ ./"
         ]
     },
     "autoload": {

--- a/src/AnalysableFile.php
+++ b/src/AnalysableFile.php
@@ -7,7 +7,7 @@ class AnalysableFile
     protected $parser;
     protected $arguments;
     
-    public function __construct(\SplFileInfo $file, \PhpParser\Parser $parser, \cli\Arguments $arguments)
+    public function __construct(\SplFileInfo $file, \PhpParser\Parser $parser, \GetOpt\GetOpt $arguments)
     {
         $this->file = $file;
         $this->parser = $parser;

--- a/src/ApplicationArgumentsProvider.php
+++ b/src/ApplicationArgumentsProvider.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace NdB\PhpDocCheck;
+
+class ApplicationArgumentsProvider
+{
+    protected $getOpt;
+    public function __construct()
+    {
+        $this->getOpt = new \GetOpt\GetOpt([
+            \GetOpt\Option::create('x', 'exclude', \GetOpt\GetOpt::MULTIPLE_ARGUMENT)
+                ->setDescription('Directories to exclude, without slash'),
+            \GetOpt\Option::create('f', 'format', \GetOpt\GetOpt::REQUIRED_ARGUMENT)
+                ->setDescription('Output format: text, json')
+                ->setDefaultValue('text'),
+            \GetOpt\Option::create('o', 'reportFile', \GetOpt\GetOpt::REQUIRED_ARGUMENT)
+                ->setDescription('Send report output to a file')
+                ->setDefaultValue(''),
+            \GetOpt\Option::create('w', 'complexity-warning-treshold', \GetOpt\GetOpt::REQUIRED_ARGUMENT)
+                ->setDescription('Cyclomatic complexity score which is the lower bound for a warning')
+                ->setDefaultValue(4)->setValidation('is_numeric'),
+            \GetOpt\Option::create('e', 'complexity-error-treshold', \GetOpt\GetOpt::REQUIRED_ARGUMENT)
+                ->setDescription('Cyclomatic complexity score which is the lower bound for an error')
+                ->setDefaultValue(6)->setValidation('is_numeric'),
+            \GetOpt\Option::create('$', 'file-extension', \GetOpt\GetOpt::MULTIPLE_ARGUMENT)
+                ->setDescription('Valid file extensions to scan')
+                ->setDefaultValue('php'),
+            \GetOpt\Option::create('i', 'ignore-violations-on-exit', \GetOpt\GetOpt::NO_ARGUMENT)
+                ->setDescription('Will exit with a zero code, even if any violations are found'),
+            \GetOpt\Option::create('?', 'help', \GetOpt\GetOpt::NO_ARGUMENT)
+                ->setDescription('Show this help and quit'),
+            \GetOpt\Option::create('q', 'quiet', \GetOpt\GetOpt::NO_ARGUMENT)
+                ->setDescription('Don\'t show any output'),
+        ]);
+        $this->getOpt->addOperand(
+            new \GetOpt\Operand(
+                'directory',
+                \GetOpt\Operand::MULTIPLE+\GetOpt\Operand::REQUIRED
+            )
+        );
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.ExitExpression)
+     */
+    public function getArguments():\GetOpt\GetOpt
+    {
+        try {
+            $this->getOpt->process();
+        } catch (\GetOpt\ArgumentException $e) {
+            echo $e->getMessage() . "\n";
+            echo $this->getOpt->getHelpText();
+            exit; //
+        }
+        return $this->getOpt;
+    }
+}

--- a/src/FileFinder.php
+++ b/src/FileFinder.php
@@ -1,0 +1,38 @@
+<?php
+namespace NdB\PhpDocCheck;
+
+class FileFinder
+{
+    /**
+     * Builds the iterator that can find all files with multiple directories,
+     * extensions and exluded folders.
+     */
+    public function getFiles(\GetOpt\GetOpt $arguments):\Iterator
+    {
+        $filesToAnalyse = new \AppendIterator();
+        foreach ($arguments->getOperand('directory') as $directory) {
+            $directoryIterator = new \RecursiveDirectoryIterator($directory);
+            $directoryIterator = new \RecursiveIteratorIterator($directoryIterator);
+            $filesToAnalyse->append($directoryIterator);
+        }
+
+        foreach ($arguments['file-extension'] as $extension) {
+            $filesToAnalyse = new \RegexIterator(
+                $filesToAnalyse,
+                '/^.+\.'.$extension.'$/i',
+                \RecursiveRegexIterator::GET_MATCH
+            );
+        }
+
+        foreach ($arguments['exclude'] as $exclude) {
+            $regex = '/^((?!'. preg_quote($exclude, '/').').)*$/i';
+                $filesToAnalyse = new \RegexIterator(
+                    $filesToAnalyse,
+                    $regex,
+                    \RecursiveRegexIterator::GET_MATCH,
+                    \RegexIterator::USE_KEY
+                );
+        }
+        return $filesToAnalyse;
+    }
+}

--- a/src/NodeVisitor.php
+++ b/src/NodeVisitor.php
@@ -27,7 +27,7 @@ class NodeVisitor extends \PhpParser\NodeVisitorAbstract
         'PhpParser\Node\Expr\BinaryOp\Coalesce',
     );
 
-    public function __construct(AnalysisResult &$analysisResult, \cli\Arguments $arguments)
+    public function __construct(AnalysisResult &$analysisResult, \GetOpt\GetOpt $arguments)
     {
         $this->analysisResult =& $analysisResult;
         $this->arguments = $arguments;


### PR DESCRIPTION
So the GetOpt library offers a couple of advantages to the php-cli-tools
library I used before to do the argument handling for this project.

Mainly the advantages are:
1. The operand allows the users to enter at least one directory to scan
which was only possible to do with an option with the previous method.
2. Validation of option inputs, such as numbers guides the user
toward correct syntax.
3. More natural method of adding multiple arguments as an array. Before
this has to be used with comma-seperated syntax or other custom
input syntax. Now the user can just use the same parameter multiple times
such as the `--exclude` and `--file-extension` options in this package.

The command line arguments have changed a bit, so this change will be in the
v0.2.0 release. #3 will be part of the same release, so the default behaviour
only changes once.