### PR TITLE
Fixes #28, allows for grouping of results in different ways.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ Options:
                                             [default: 6]
   -$, --file-extension <arg>                Valid file extensions to scan
                                             [default: php]
+  -g, --grouping-method <arg>               Allows different grouping of the
+                                            results list [file, none, metric,
+                                            severity, fileline] [default: file]
   -i, --ignore-violations-on-exit           Will exit with a zero code, even if
                                             any violations are found
   -?, --help                                Show this help and quit

--- a/bin/php-doc-check
+++ b/bin/php-doc-check
@@ -54,15 +54,16 @@ $parser = (new \PhpParser\ParserFactory)->create(
 
 $analysisResults = array();
 $fileFinder = new \NdB\PhpDocCheck\FileFinder();
+$groupManager = new \NdB\PhpDocCheck\GroupManager($arguments->getOption('grouping-method'));
 foreach ($fileFinder->getFiles($arguments) as $name => $object) {
-    $file = new \NdB\PhpDocCheck\AnalysableFile(new SplFileInfo($name), $parser, $arguments);
+    $file = new \NdB\PhpDocCheck\AnalysableFile(new SplFileInfo($name), $parser, $arguments, $groupManager);
     $result = $file->analyse();
     $outputFormatter->progress($result->getProgressIndicator());
     $analysisResults[] = $result;
 }
 $outputFormatter->progress("\n");
 
-$outputFormatter->result($analysisResults);
+$outputFormatter->result($groupManager->getGroups());
 
 if ($arguments['ignore-violations-on-exit']) {
     exit(0);

--- a/src/AnalysisResult.php
+++ b/src/AnalysisResult.php
@@ -18,7 +18,7 @@ class AnalysisResult implements \JsonSerializable
         return $this->sourceFile;
     }
 
-    public function addFinding(Findings\Finding $finding)
+    public function addProgress(Findings\Finding $finding)
     {
         $this->findings[] = $finding;
         if (is_a($finding, 'NdB\PhpDocCheck\Findings\Error')) {

--- a/src/ApplicationArgumentsProvider.php
+++ b/src/ApplicationArgumentsProvider.php
@@ -30,6 +30,12 @@ class ApplicationArgumentsProvider
             \GetOpt\Option::create('$', 'file-extension', \GetOpt\GetOpt::MULTIPLE_ARGUMENT)
                 ->setDescription('Valid file extensions to scan [default: php]')
                 ->setDefaultValue('php'),
+            \GetOpt\Option::create('g', 'grouping-method', \GetOpt\GetOpt::REQUIRED_ARGUMENT)
+                ->setDescription(
+                    'Allows different grouping of the results list '.
+                    '[file, none, metric, severity, fileline] [default: file]'
+                )
+                ->setDefaultValue('file'),
             \GetOpt\Option::create('i', 'ignore-violations-on-exit', \GetOpt\GetOpt::NO_ARGUMENT)
                 ->setDescription('Will exit with a zero code, even if any violations are found'),
             \GetOpt\Option::create('?', 'help', \GetOpt\GetOpt::NO_ARGUMENT)

--- a/src/Findings/Finding.php
+++ b/src/Findings/Finding.php
@@ -2,7 +2,7 @@
 
 namespace NdB\PhpDocCheck\Findings;
 
-abstract class Finding implements \JsonSerializable
+abstract class Finding implements \JsonSerializable, Groupable
 {
     public $message;
     public $node;
@@ -21,6 +21,28 @@ abstract class Finding implements \JsonSerializable
         $this->metric     = $metric;
     }
     
+    public function getGroupKey(string $groupingMethod) : string
+    {
+        switch ($groupingMethod) {
+            case 'none':
+                $groupKey = 'none';
+                break;
+            case 'metric':
+                $groupKey = $this->metric->getName();
+                break;
+            case 'severity':
+                $groupKey = $this->getType();
+                break;
+            case 'fileline':
+                $groupKey = $this->sourceFile->file->getRealPath().":".$this->getLine();
+                break;
+            case 'file':
+            default:
+                $groupKey = $this->sourceFile->file->getRealPath();
+        }
+        return $groupKey;
+    }
+
     public function getLine():int
     {
         return $this->node->getStartLine();

--- a/src/Findings/Groupable.php
+++ b/src/Findings/Groupable.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace NdB\PhpDocCheck\Findings;
+
+interface Groupable
+{
+    public function getGroupKey(string $groupingMethod) : string;
+}

--- a/src/GroupContainer.php
+++ b/src/GroupContainer.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace NdB\PhpDocCheck;
+
+interface GroupContainer
+{
+    public function addFinding(Findings\Groupable $finding);
+    public function getGroups(): array;
+}

--- a/src/GroupManager.php
+++ b/src/GroupManager.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace NdB\PhpDocCheck;
+
+class GroupManager implements GroupContainer
+{
+    protected $groupingMethod = 'file';
+    protected $groups = array();
+    public function __construct($groupingMethod)
+    {
+        $this->groupingMethod = $groupingMethod;
+    }
+
+    public function addFinding(Findings\Groupable $finding)
+    {
+        if (!array_key_exists($finding->getGroupKey($this->groupingMethod), $this->groups)) {
+            $this->groups[$finding->getGroupKey($this->groupingMethod)] = new ResultGroup(
+                $finding->getGroupKey($this->groupingMethod)
+            );
+        }
+        $this->groups[$finding->getGroupKey($this->groupingMethod)]->addFinding($finding);
+    }
+
+    public function getGroups(): array
+    {
+        return $this->groups;
+    }
+}

--- a/src/NodeVisitor.php
+++ b/src/NodeVisitor.php
@@ -11,16 +11,19 @@ class NodeVisitor extends \PhpParser\NodeVisitorAbstract
     protected $arguments;
     protected $sourceFile;
     protected $metric;
+    protected $groupManager;
 
     public function __construct(
         AnalysisResult &$analysisResult,
         AnalysableFile $file,
-        \NdB\PhpDocCheck\Metrics\Metric $metric
+        \NdB\PhpDocCheck\Metrics\Metric $metric,
+        GroupManager $groupManager
     ) {
         $this->analysisResult =& $analysisResult;
         $this->sourceFile     = $file;
         $this->arguments      = $file->arguments;
         $this->metric         = $metric;
+        $this->groupManager   = $groupManager;
     }
 
     /**
@@ -38,23 +41,23 @@ class NodeVisitor extends \PhpParser\NodeVisitorAbstract
             }
             if (empty($node->getDocComment())) {
                 if ($metricValue >= $this->arguments->getOption('complexity-error-threshold')) {
-                    $this->analysisResult->addFinding(
-                        new \NdB\PhpDocCheck\Findings\Error(
-                            sprintf("%s has no documentation and a complexity of %d", $name, $metricValue),
-                            $node,
-                            $this->sourceFile,
-                            $this->metric
-                        )
+                    $finding = new \NdB\PhpDocCheck\Findings\Error(
+                        sprintf("%s has no documentation and a complexity of %d", $name, $metricValue),
+                        $node,
+                        $this->sourceFile,
+                        $this->metric
                     );
+                    $this->analysisResult->addProgress($finding);
+                    $this->groupManager->addFinding($finding);
                 } elseif ($metricValue >= $this->arguments->getOption('complexity-warning-threshold')) {
-                    $this->analysisResult->addFinding(
-                        new \NdB\PhpDocCheck\Findings\Warning(
-                            sprintf("%s has no documentation and a complexity of %d", $name, $metricValue),
-                            $node,
-                            $this->sourceFile,
-                            $this->metric
-                        )
+                    $finding = new \NdB\PhpDocCheck\Findings\Warning(
+                        sprintf("%s has no documentation and a complexity of %d", $name, $metricValue),
+                        $node,
+                        $this->sourceFile,
+                        $this->metric
                     );
+                    $this->analysisResult->addProgress($finding);
+                    $this->groupManager->addFinding($finding);
                 }
             }
         }

--- a/src/Output/Formats/Format.php
+++ b/src/Output/Formats/Format.php
@@ -14,14 +14,9 @@ abstract class Format
     }
 
     /**
-     * @param \NdB\PhpDocCheck\AnalysisResult[] $results
+     * @param \NdB\PhpDocCheck\ResultGroup[] $results
      */
     abstract protected function get(array $results) : string;
-
-    protected function removeEmpty(\NdB\PhpDocCheck\AnalysisResult $analysisResult) : bool
-    {
-        return !empty($analysisResult->findings);
-    }
 
     /**
      * Determines if this scan has 'failed' and should be fixed. Or if it was
@@ -40,7 +35,7 @@ abstract class Format
     }
 
     /**
-     * @param \NdB\PhpDocCheck\AnalysisResult[] $results
+     * @param \NdB\PhpDocCheck\ResultGroup[] $results
      */
     abstract public function result(array $results);
     abstract public function out(string $output);

--- a/src/Output/Formats/Json.php
+++ b/src/Output/Formats/Json.php
@@ -5,9 +5,7 @@ final class Json extends Format
 {
     protected function get(array $results) : string
     {
-        $output = array();
-        $output = array_filter($results, array($this, 'removeEmpty'));
-        return (string) json_encode($output);
+        return (string) json_encode($results);
     }
 
     public function result(array $results)

--- a/src/Output/Formats/Text.php
+++ b/src/Output/Formats/Text.php
@@ -5,25 +5,26 @@ final class Text extends Format
 {
     protected function get(array $results) : string
     {
-        $results = array_filter($results, array($this, 'removeEmpty'));
         $output = '';
-        foreach ($results as $analysisResult) {
-            $output .= $this->getFileOutput($analysisResult);
+        foreach ($results as $resultGroup) {
+            if (!empty($resultGroup->getFindings())) {
+                $output .= $this->getFileOutput($resultGroup);
+            }
         }
         return $output;
     }
 
-    protected function getFileOutput(\NdB\PhpDocCheck\AnalysisResult $analysisResult)
+    protected function getFileOutput(\NdB\PhpDocCheck\ResultGroup $resultGroup)
     {
         $output = '';
         $output .= "\n";
-        $output .= sprintf("File: %s\n", $analysisResult->sourceFile->file->getRealPath());
+        $output .= sprintf("Group: %s\n", $resultGroup->getName());
         $header = array(
             'Severity',
             'Message',
             'Line'
         );
-        $rows = array_map(array($this, 'formatRow'), $analysisResult->findings);
+        $rows = array_map(array($this, 'formatRow'), $resultGroup->getFindings());
         $lines = (new \cli\Table($header, $rows))->getDisplayLines();
         foreach ($lines as $line) {
             $output .= $line. "\n";

--- a/src/ResultGroup.php
+++ b/src/ResultGroup.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace NdB\PhpDocCheck;
+
+class ResultGroup implements \JsonSerializable
+{
+    public $name;
+    protected $findings = array();
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName():string
+    {
+        return $this->name;
+    }
+
+    public function addFinding(Findings\Finding $finding)
+    {
+        $this->findings[] = $finding;
+    }
+
+    public function getFindings(): array
+    {
+        return $this->findings;
+    }
+
+    public function jsonSerialize() : array
+    {
+        return array(
+            'groupName'=>$this->getName(),
+            'findings'=>$this->getFindings(),
+        );
+    }
+}

--- a/tests/AnalysisResultTest.php
+++ b/tests/AnalysisResultTest.php
@@ -30,7 +30,7 @@ final class AnalysisResultTest extends \PHPUnit\Framework\TestCase
             $this->analysableFile,
             $this->metric
         );
-        $analysisResult->addFinding($finding);
+        $analysisResult->addProgress($finding);
         $this->assertEquals('W', $analysisResult->getProgressIndicator());
         return $analysisResult;
     }
@@ -46,7 +46,7 @@ final class AnalysisResultTest extends \PHPUnit\Framework\TestCase
             $this->analysableFile,
             $this->metric
         );
-        $analysisResult->addFinding($finding);
+        $analysisResult->addProgress($finding);
         $this->assertEquals('E', $analysisResult->getProgressIndicator());
         return $analysisResult;
     }

--- a/tests/NodeVisitorTest.php
+++ b/tests/NodeVisitorTest.php
@@ -8,7 +8,7 @@ final class NodeVisitorTest extends \PHPUnit\Framework\TestCase
     {
         $analysisResult = $this->createMock(AnalysisResult::class);
         $analysisResult->expects($this->once())
-            ->method('addFinding')
+            ->method('addProgress')
             ->with($this->isInstanceOf(\NdB\PhpDocCheck\Findings\Warning::class));
         $arguments = $this->createMock(\GetOpt\GetOpt::class);
         $arguments->method('getOption')->will($this->onConsecutiveCalls(6, 4));
@@ -16,7 +16,8 @@ final class NodeVisitorTest extends \PHPUnit\Framework\TestCase
         $analysableFile->arguments = $arguments;
         $metric = $this->createMock(\NdB\PhpDocCheck\Metrics\Metric::class);
         $metric->method('getValue')->willReturn(4);
-        $nodeVisitor = new NodeVisitor($analysisResult, $analysableFile, $metric);
+        $groupManager = new \NdB\PhpDocCheck\GroupManager('none');
+        $nodeVisitor = new NodeVisitor($analysisResult, $analysableFile, $metric, $groupManager);
         $node = $this->createMock(\PhpParser\Node\Stmt\Function_::class);
         $nodeVisitor->leaveNode($node);
     }
@@ -25,7 +26,7 @@ final class NodeVisitorTest extends \PHPUnit\Framework\TestCase
     {
         $analysisResult = $this->createMock(AnalysisResult::class);
         $analysisResult->expects($this->once())
-            ->method('addFinding')
+            ->method('addProgress')
             ->with($this->isInstanceOf(\NdB\PhpDocCheck\Findings\Error::class));
         $arguments = $this->createMock(\GetOpt\GetOpt::class);
         $arguments->method('getOption')->will($this->onConsecutiveCalls(6, 4));
@@ -33,7 +34,8 @@ final class NodeVisitorTest extends \PHPUnit\Framework\TestCase
         $analysableFile->arguments = $arguments;
         $metric = $this->createMock(\NdB\PhpDocCheck\Metrics\Metric::class);
         $metric->method('getValue')->willReturn(9);
-        $nodeVisitor = new NodeVisitor($analysisResult, $analysableFile, $metric);
+        $groupManager = $this->createMock(\NdB\PhpDocCheck\GroupManager::class);
+        $nodeVisitor = new NodeVisitor($analysisResult, $analysableFile, $metric, $groupManager);
         $node = $this->createMock(\PhpParser\Node\Stmt\Function_::class);
         $nodeVisitor->leaveNode($node);
     }

--- a/tests/Output/Formats/JsonTest.php
+++ b/tests/Output/Formats/JsonTest.php
@@ -9,9 +9,9 @@ final class JsonTest extends \PHPUnit\Framework\TestCase
         $channel = $this->createMock(\NdB\PhpDocCheck\Output\Channels\Channel::class);
         $channel->expects($this->once())
             ->method('out')
-            ->with('[]');
+            ->with('[[]]');
         $formatter = new Json(array($channel));
-        $results = $this->createMock(\NdB\PhpDocCheck\AnalysisResult::class);
+        $results = $this->createMock(\NdB\PhpDocCheck\ResultGroup::class);
         $formatter->result(array($results));
     }
 }

--- a/tests/Output/Formats/TextTest.php
+++ b/tests/Output/Formats/TextTest.php
@@ -11,7 +11,7 @@ final class TextTest extends \PHPUnit\Framework\TestCase
             ->method('out')
             ->with('');
         $formatter = new Text(array($channel));
-        $results = $this->createMock(\NdB\PhpDocCheck\AnalysisResult::class);
+        $results = $this->createMock(\NdB\PhpDocCheck\ResultGroup::class);
         $formatter->result(array($results));
     }
 
@@ -22,13 +22,13 @@ final class TextTest extends \PHPUnit\Framework\TestCase
             ->method('out')
             ->with($this->stringContains('Basic warning'));
         $formatter = new Text(array($channel));
-        $results = $this->createMock(\NdB\PhpDocCheck\AnalysisResult::class);
+        $results = $this->createMock(\NdB\PhpDocCheck\ResultGroup::class);
         $metric = $this->createMock('\NdB\PhpDocCheck\Metrics\Metric');
         $analysableFile = $this->createMock('\NdB\PhpDocCheck\AnalysableFile');
         $node = $this->createMock('\PhpParser\Node');
-        $results->findings = array(
+        $results->method('getFindings')->willReturn(array(
             new \NdB\PhpDocCheck\Findings\Warning("Basic warning", $node, $analysableFile, $metric)
-        );
+        ));
         $results->sourceFile = $this->createMock(\NdB\PhpDocCheck\AnalysableFile::class);
         $results->sourceFile->file = $this->createMock(\SplFileInfo::class);
         $results->sourceFile->file->method('getRealPath')->willReturn('/tmp/test');


### PR DESCRIPTION
Adds the following new option:

`  -g, --grouping-method <arg>`

Allows different grouping of the results list [default: file]

file, Groups findings in the same file together
none, Throws everything in a single group, to allow for global ordering (see #30)
metric, Groups by metric name, so you can solve one category of problem at a time
severity, Groups errors and warnings together
fileline, Groups by filename with the line number of the warning appended, so this is practically a group by function/method.