### PR TITLE
Fixes #29, Fixes #30, Adds sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ Options:
   -g, --grouping-method <arg>               Allows different grouping of the
                                             results list [file, none, metric,
                                             severity, fileline] [default: file]
+  -s, --sorting-method <arg>                Sorting for the results. Natural
+                                            sorts by name for groups and line
+                                            for findings. Value uses the
+                                            cumulative group score, and finding
+                                            score as sorting value. [natural,
+                                            value] [default: natural]
   -i, --ignore-violations-on-exit           Will exit with a zero code, even if
                                             any violations are found
   -?, --help                                Show this help and quit

--- a/bin/php-doc-check
+++ b/bin/php-doc-check
@@ -54,7 +54,7 @@ $parser = (new \PhpParser\ParserFactory)->create(
 
 $analysisResults = array();
 $fileFinder = new \NdB\PhpDocCheck\FileFinder();
-$groupManager = new \NdB\PhpDocCheck\GroupManager($arguments->getOption('grouping-method'));
+$groupManager = new \NdB\PhpDocCheck\GroupManager($arguments->getOption('grouping-method'), $arguments->getOption('sorting-method'));
 foreach ($fileFinder->getFiles($arguments) as $name => $object) {
     $file = new \NdB\PhpDocCheck\AnalysableFile(new SplFileInfo($name), $parser, $arguments, $groupManager);
     $result = $file->analyse();

--- a/src/AnalysableFile.php
+++ b/src/AnalysableFile.php
@@ -34,7 +34,8 @@ class AnalysableFile implements \JsonSerializable
                 sprintf('Failed parsing: %s', $e->getRawMessage()),
                 new InvalidFileNode,
                 $this,
-                new \NdB\PhpDocCheck\Metrics\InvalidFile()
+                new \NdB\PhpDocCheck\Metrics\InvalidFile(),
+                0
             );
             $analysisResult->addProgress($finding);
             $this->groupManager->addFinding($finding);

--- a/src/ApplicationArgumentsProvider.php
+++ b/src/ApplicationArgumentsProvider.php
@@ -36,6 +36,13 @@ class ApplicationArgumentsProvider
                     '[file, none, metric, severity, fileline] [default: file]'
                 )
                 ->setDefaultValue('file'),
+            \GetOpt\Option::create('s', 'sorting-method', \GetOpt\GetOpt::REQUIRED_ARGUMENT)
+                ->setDescription(
+                    'Sorting for the results. Natural sorts by name for groups and line for findings. '.
+                    'Value uses the cumulative group score, and finding score as sorting value. '.
+                    '[natural, value] [default: natural]'
+                )
+                ->setDefaultValue('file'),
             \GetOpt\Option::create('i', 'ignore-violations-on-exit', \GetOpt\GetOpt::NO_ARGUMENT)
                 ->setDescription('Will exit with a zero code, even if any violations are found'),
             \GetOpt\Option::create('?', 'help', \GetOpt\GetOpt::NO_ARGUMENT)

--- a/src/Findings/Finding.php
+++ b/src/Findings/Finding.php
@@ -2,25 +2,31 @@
 
 namespace NdB\PhpDocCheck\Findings;
 
-abstract class Finding implements \JsonSerializable, Groupable
+abstract class Finding implements \JsonSerializable, Groupable, \NdB\PhpDocCheck\Sortable
 {
     public $message;
     public $node;
     public $sourceFile;
     public $metric;
+    public $value;
 
     public function __construct(
         string $message,
         \PhpParser\Node $node,
         \NdB\PhpDocCheck\AnalysableFile $sourceFile,
-        \NdB\PhpDocCheck\Metrics\Metric $metric
+        \NdB\PhpDocCheck\Metrics\Metric $metric,
+        int $value
     ) {
         $this->message    = $message;
         $this->node       = $node;
         $this->sourceFile = $sourceFile;
         $this->metric     = $metric;
+        $this->value      = $value;
     }
     
+    /**
+     * Based on the group key, new groups are made by the groupManager.
+     */
     public function getGroupKey(string $groupingMethod) : string
     {
         switch ($groupingMethod) {
@@ -55,11 +61,20 @@ abstract class Finding implements \JsonSerializable, Groupable
 
     abstract public function getType():string;
 
+    public function getSortValue($sortMethod): string
+    {
+        if ($sortMethod === 'value') {
+            return (string) $this->value;
+        }
+        return (string) $this->getLine();
+    }
+
     public function jsonSerialize() : array
     {
         return array(
             'message'=> $this->getMessage(),
             'type'=> $this->getType(),
+            'value'=> $this->value,
             'metric'=> $this->metric,
             'sourceFile'=> $this->sourceFile,
             'node'=> array(

--- a/src/GroupManager.php
+++ b/src/GroupManager.php
@@ -5,17 +5,20 @@ namespace NdB\PhpDocCheck;
 class GroupManager implements GroupContainer
 {
     protected $groupingMethod = 'file';
+    protected $sortingMethod = 'natural';
     protected $groups = array();
-    public function __construct($groupingMethod)
+    public function __construct(string $groupingMethod, string $sortingMethod)
     {
         $this->groupingMethod = $groupingMethod;
+        $this->sortingMethod  = $sortingMethod;
     }
 
     public function addFinding(Findings\Groupable $finding)
     {
         if (!array_key_exists($finding->getGroupKey($this->groupingMethod), $this->groups)) {
             $this->groups[$finding->getGroupKey($this->groupingMethod)] = new ResultGroup(
-                $finding->getGroupKey($this->groupingMethod)
+                $finding->getGroupKey($this->groupingMethod),
+                $this->sortingMethod
             );
         }
         $this->groups[$finding->getGroupKey($this->groupingMethod)]->addFinding($finding);
@@ -23,6 +26,15 @@ class GroupManager implements GroupContainer
 
     public function getGroups(): array
     {
+        uasort($this->groups, function ($prev, $next) {
+            if ($prev->getSortValue($this->sortingMethod) == $next->getSortValue($this->sortingMethod)) {
+                return 0;
+            }
+            return ($prev->getSortValue($this->sortingMethod) < $next->getSortValue($this->sortingMethod)) ? -1 : 1;
+        });
+        if ($this->sortingMethod === 'value') {
+            $this->groups = array_reverse($this->groups, true);
+        }
         return $this->groups;
     }
 }

--- a/src/Metrics/CognitiveComplexity.php
+++ b/src/Metrics/CognitiveComplexity.php
@@ -24,7 +24,6 @@ final class CognitiveComplexity implements Metric
         'Expr_BinaryOp_Coalesce',
         'Expr_Ternary',
     );
-    public $value;
 
     public function getName():string
     {
@@ -33,10 +32,7 @@ final class CognitiveComplexity implements Metric
 
     public function getValue(\PhpParser\Node $node):int
     {
-        if (is_null($this->value)) {
-            $this->value = $this->calculateNodeValue($node, 0);
-        }
-        return $this->value;
+        return $this->calculateNodeValue($node, 0);
     }
 
     /**
@@ -74,8 +70,7 @@ final class CognitiveComplexity implements Metric
     public function jsonSerialize() : array
     {
         return array(
-            'name'=>$this->getName(),
-            'value'=>$this->value
+            'name'=>$this->getName()
         );
     }
 }

--- a/src/Metrics/CyclomaticComplexity.php
+++ b/src/Metrics/CyclomaticComplexity.php
@@ -21,7 +21,6 @@ final class CyclomaticComplexity implements Metric
         'Expr_Ternary',
     );
 
-    public $value;
 
     public function getName():string
     {
@@ -30,10 +29,7 @@ final class CyclomaticComplexity implements Metric
 
     public function getValue(\PhpParser\Node $node):int
     {
-        if (is_null($this->value)) {
-            $this->value = $this->calculateNodeValue($node) + 1;
-        }
-        return $this->value;
+        return $this->calculateNodeValue($node) + 1;
     }
 
     /**
@@ -69,7 +65,6 @@ final class CyclomaticComplexity implements Metric
     {
         return array(
             'name'=>$this->getName(),
-            'value'=>$this->value
         );
     }
 }

--- a/src/NodeVisitor.php
+++ b/src/NodeVisitor.php
@@ -45,7 +45,8 @@ class NodeVisitor extends \PhpParser\NodeVisitorAbstract
                         sprintf("%s has no documentation and a complexity of %d", $name, $metricValue),
                         $node,
                         $this->sourceFile,
-                        $this->metric
+                        $this->metric,
+                        $metricValue
                     );
                     $this->analysisResult->addProgress($finding);
                     $this->groupManager->addFinding($finding);
@@ -54,7 +55,8 @@ class NodeVisitor extends \PhpParser\NodeVisitorAbstract
                         sprintf("%s has no documentation and a complexity of %d", $name, $metricValue),
                         $node,
                         $this->sourceFile,
-                        $this->metric
+                        $this->metric,
+                        $metricValue
                     );
                     $this->analysisResult->addProgress($finding);
                     $this->groupManager->addFinding($finding);

--- a/src/Output/Formats/Text.php
+++ b/src/Output/Formats/Text.php
@@ -18,7 +18,7 @@ final class Text extends Format
     {
         $output = '';
         $output .= "\n";
-        $output .= sprintf("Group: %s\n", $resultGroup->getName());
+        $output .= sprintf("Group: %s (score: %d)\n", $resultGroup->getName(), $resultGroup->getValue());
         $header = array(
             'Severity',
             'Message',

--- a/src/ResultGroup.php
+++ b/src/ResultGroup.php
@@ -2,14 +2,16 @@
 
 namespace NdB\PhpDocCheck;
 
-class ResultGroup implements \JsonSerializable
+class ResultGroup implements \JsonSerializable, Sortable
 {
     public $name;
+    public $sortingMethod;
     protected $findings = array();
 
-    public function __construct(string $name)
+    public function __construct(string $name, string $sortingMethod)
     {
         $this->name = $name;
+        $this->sortingMethod = $sortingMethod;
     }
 
     public function getName():string
@@ -24,6 +26,15 @@ class ResultGroup implements \JsonSerializable
 
     public function getFindings(): array
     {
+        uasort($this->findings, function ($prev, $next) {
+            if ($prev->getSortValue($this->sortingMethod) == $next->getSortValue($this->sortingMethod)) {
+                return 0;
+            }
+            return ($prev->getSortValue($this->sortingMethod) < $next->getSortValue($this->sortingMethod)) ? -1 : 1;
+        });
+        if ($this->sortingMethod === 'value') {
+            $this->findings = array_reverse($this->findings, true);
+        }
         return $this->findings;
     }
 
@@ -32,6 +43,22 @@ class ResultGroup implements \JsonSerializable
         return array(
             'groupName'=>$this->getName(),
             'findings'=>$this->getFindings(),
+            'value'=>$this->getValue()
         );
+    }
+
+    public function getValue() : int
+    {
+        return array_reduce($this->getFindings(), function (int $carry, Findings\Finding $finding) {
+            return $carry + $finding->value;
+        }, 0);
+    }
+
+    public function getSortValue($sortMethod): string
+    {
+        if ($sortMethod === 'value') {
+            return (string) $this->getValue();
+        }
+        return $this->getName();
     }
 }

--- a/src/Sortable.php
+++ b/src/Sortable.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace NdB\PhpDocCheck;
+
+interface Sortable
+{
+    public function getSortValue($sortMethod): string;
+}

--- a/tests/AnalysisResultTest.php
+++ b/tests/AnalysisResultTest.php
@@ -28,7 +28,8 @@ final class AnalysisResultTest extends \PHPUnit\Framework\TestCase
             "Basic warning",
             $this->node,
             $this->analysableFile,
-            $this->metric
+            $this->metric,
+            0
         );
         $analysisResult->addProgress($finding);
         $this->assertEquals('W', $analysisResult->getProgressIndicator());
@@ -44,7 +45,8 @@ final class AnalysisResultTest extends \PHPUnit\Framework\TestCase
             "Basic error",
             $this->node,
             $this->analysableFile,
-            $this->metric
+            $this->metric,
+            1
         );
         $analysisResult->addProgress($finding);
         $this->assertEquals('E', $analysisResult->getProgressIndicator());

--- a/tests/NodeVisitorTest.php
+++ b/tests/NodeVisitorTest.php
@@ -16,7 +16,7 @@ final class NodeVisitorTest extends \PHPUnit\Framework\TestCase
         $analysableFile->arguments = $arguments;
         $metric = $this->createMock(\NdB\PhpDocCheck\Metrics\Metric::class);
         $metric->method('getValue')->willReturn(4);
-        $groupManager = new \NdB\PhpDocCheck\GroupManager('none');
+        $groupManager = new \NdB\PhpDocCheck\GroupManager('none', 'natural');
         $nodeVisitor = new NodeVisitor($analysisResult, $analysableFile, $metric, $groupManager);
         $node = $this->createMock(\PhpParser\Node\Stmt\Function_::class);
         $nodeVisitor->leaveNode($node);

--- a/tests/Output/Formats/TextTest.php
+++ b/tests/Output/Formats/TextTest.php
@@ -27,7 +27,7 @@ final class TextTest extends \PHPUnit\Framework\TestCase
         $analysableFile = $this->createMock('\NdB\PhpDocCheck\AnalysableFile');
         $node = $this->createMock('\PhpParser\Node');
         $results->method('getFindings')->willReturn(array(
-            new \NdB\PhpDocCheck\Findings\Warning("Basic warning", $node, $analysableFile, $metric)
+            new \NdB\PhpDocCheck\Findings\Warning("Basic warning", $node, $analysableFile, $metric, 0)
         ));
         $results->sourceFile = $this->createMock(\NdB\PhpDocCheck\AnalysableFile::class);
         $results->sourceFile->file = $this->createMock(\SplFileInfo::class);


### PR DESCRIPTION
Two sorting options have been added. 

- `natural` allows for the same output that was default before, which is groups are sorted by filename, ascending. Findings are sorted by line number.
- `value` sorts group by the sum of all values of findings in the group, descending. The findings are sorted by their metric value/score, descending.
