### PR TITLE
Update dependencies & ability to ignore anonymous functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Options:
                                             value] [default: natural]
   -i, --ignore-violations-on-exit           Will exit with a zero code, even if
                                             any violations are found
+  -a, --ignore-anonymous-functions          Skip checks on anonymous functions
   -?, --help                                Show this help and quit
   -q, --quiet                               Don't show any output
 ```

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "nikic/php-parser": "^4.2",
         "wp-cli/php-cli-tools": "^0.11.11",
         "ulrichsg/getopt-php": "^3.2",
-        "phpdocumentor/reflection-docblock": "^4.3"
+        "phpdocumentor/reflection-docblock": "^4.3|^5.0"
     },
     "bin": [
         "bin/php-doc-check"

--- a/src/ApplicationArgumentsProvider.php
+++ b/src/ApplicationArgumentsProvider.php
@@ -45,6 +45,8 @@ class ApplicationArgumentsProvider
                     '[natural, value] [default: natural]'
                 )
                 ->setDefaultValue('file'),
+            \GetOpt\Option::create('a', 'ignore-anonymous-functions', \GetOpt\GetOpt::NO_ARGUMENT)
+                ->setDescription('Will ignore anonymous functions on checks'),
             \GetOpt\Option::create('i', 'ignore-violations-on-exit', \GetOpt\GetOpt::NO_ARGUMENT)
                 ->setDescription('Will exit with a zero code, even if any violations are found'),
             \GetOpt\Option::create('?', 'help', \GetOpt\GetOpt::NO_ARGUMENT)

--- a/src/NodeVisitors/MetricChecker.php
+++ b/src/NodeVisitors/MetricChecker.php
@@ -46,6 +46,9 @@ class MetricChecker extends \PhpParser\NodeVisitorAbstract
                     $name = $node->namespacedName . '()';
                 }
             }
+            if ($name == 'Anonymous function' && $this->arguments['ignore-anonymous-functions']) {
+                return;
+            }
             $node->setAttribute('FQSEN', $name);
             
             if ($metricValue >= $this->arguments->getOption('complexity-error-threshold')) {


### PR DESCRIPTION
1. phpdocumentor has now version 5, which is compatible with php 8.*, unlike previous version
2. It is useful to have an ability to ignore anonymous functions, such as database transactions